### PR TITLE
fix(builders): extend gh-create-pr trusted evidence inputs

### DIFF
--- a/builders/packet-workflow/retained-skills/gh-create-pr/SKILL.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/SKILL.md
@@ -25,6 +25,7 @@ Use this skill to open a new GitHub pull request from a branch already pushed to
 
 1. Run `gh auth status`; stop if authentication is missing.
 2. Collect context with `<python-bin> -B <skill-dir>/scripts/collect_pr_create_context.py --repo-root <repo-root> ... --output <context-json>`.
+   Add repeated `--issue-hint <n>` only when the issue linkage comes from trusted operator context rather than branch or commit metadata.
 3. Run lint and packet build with `lint_pr_create.py` and `build_pr_create_packets.py`.
 4. Initialize the evaluation log, then merge the build result.
 5. Read `orchestrator.json` first, then `rules_packet.json`, then `synthesis_packet.json`, then at most one focused packet.

--- a/builders/packet-workflow/retained-skills/gh-create-pr/SKILL.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/SKILL.md
@@ -26,6 +26,7 @@ Use this skill to open a new GitHub pull request from a branch already pushed to
 1. Run `gh auth status`; stop if authentication is missing.
 2. Collect context with `<python-bin> -B <skill-dir>/scripts/collect_pr_create_context.py --repo-root <repo-root> ... --output <context-json>`.
    Add repeated `--issue-hint <n>` only when the issue linkage comes from trusted operator context rather than branch or commit metadata.
+   Add repeated `--test-command "<exact command>"` only when trusted operator context needs the PR body to claim specific executed tests.
 3. Run lint and packet build with `lint_pr_create.py` and `build_pr_create_packets.py`.
 4. Initialize the evaluation log, then merge the build result.
 5. Read `orchestrator.json` first, then `rules_packet.json`, then `synthesis_packet.json`, then at most one focused packet.

--- a/builders/packet-workflow/retained-skills/gh-create-pr/references/pr-create-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/references/pr-create-contract.md
@@ -20,6 +20,7 @@ Collector CLI:
 - optional `--repo`
 - optional `--base`
 - optional `--head`
+- repeated `--issue-hint`
 - repeated `--reviewer`
 - repeated `--assignee`
 - repeated `--label`
@@ -32,6 +33,8 @@ Collector CLI:
 Resolution rules:
 - base resolution order is `--base`, `branch.<current>.gh-merge-base`, remote default branch
 - head resolution order is `--head`, current branch
+- explicit issue hints must come from repeated `--issue-hint` inputs and normalize only exact `15` / `#15` values
+- collected issue-reference hints merge branch metadata, commit-subject metadata, and trusted explicit issue hints
 - v1 stops closed when the resolved remote head does not exist
 
 Collector output must include:
@@ -117,7 +120,7 @@ Candidate lint:
 - title/body claims must be grounded in runtime/process/testing packet evidence
 
 Strict claim gates:
-- issue references require process-packet issue hints
+- issue references require process-packet issue hints, whether derived from branch/commit metadata or trusted explicit collector input
 - positive testing claims require exact commands from testing evidence
 - `no behavior change` is allowed only when runtime packet is empty
 - rollout, restart/reload, and consumer migration/compatibility claims fail closed by default

--- a/builders/packet-workflow/retained-skills/gh-create-pr/references/pr-create-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/references/pr-create-contract.md
@@ -21,6 +21,7 @@ Collector CLI:
 - optional `--base`
 - optional `--head`
 - repeated `--issue-hint`
+- repeated `--test-command`
 - repeated `--reviewer`
 - repeated `--assignee`
 - repeated `--label`
@@ -34,6 +35,7 @@ Resolution rules:
 - base resolution order is `--base`, `branch.<current>.gh-merge-base`, remote default branch
 - head resolution order is `--head`, current branch
 - explicit issue hints must come from repeated `--issue-hint` inputs and normalize only exact `15` / `#15` values
+- explicit testing evidence must come from repeated `--test-command` inputs and normalize only exact single-line commands
 - collected issue-reference hints merge branch metadata, commit-subject metadata, and trusted explicit issue hints
 - v1 stops closed when the resolved remote head does not exist
 
@@ -121,7 +123,7 @@ Candidate lint:
 
 Strict claim gates:
 - issue references require process-packet issue hints, whether derived from branch/commit metadata or trusted explicit collector input
-- positive testing claims require exact commands from testing evidence
+- positive testing claims require exact commands from testing evidence, whether supplied by trusted collector input or a future equivalent evidence path
 - `no behavior change` is allowed only when runtime packet is empty
 - rollout, restart/reload, and consumer migration/compatibility claims fail closed by default
 - unchecked template checklist items are not treated as asserted claims until checked or rewritten as prose

--- a/builders/packet-workflow/retained-skills/gh-create-pr/references/pr-create-contract.md
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/references/pr-create-contract.md
@@ -35,7 +35,7 @@ Resolution rules:
 - base resolution order is `--base`, `branch.<current>.gh-merge-base`, remote default branch
 - head resolution order is `--head`, current branch
 - explicit issue hints must come from repeated `--issue-hint` inputs and normalize only exact `15` / `#15` values
-- explicit testing evidence must come from repeated `--test-command` inputs and normalize only exact single-line commands
+- explicit testing evidence must come from repeated `--test-command` inputs and normalize only exact single-line commands without backticks
 - collected issue-reference hints merge branch metadata, commit-subject metadata, and trusted explicit issue hints
 - v1 stops closed when the resolved remote head does not exist
 

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/collect_pr_create_context.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/collect_pr_create_context.py
@@ -125,6 +125,12 @@ def parse_args() -> argparse.Namespace:
         default=[],
         help="Trusted explicit issue hint such as `15` or `#15`. Repeat as needed.",
     )
+    parser.add_argument(
+        "--test-command",
+        action="append",
+        default=[],
+        help="Trusted exact test command to allow in positive Testing claims. Repeat as needed.",
+    )
     parser.add_argument("--reviewer", action="append", default=[], help="Raw reviewer option. Repeat as needed.")
     parser.add_argument("--assignee", action="append", default=[], help="Raw assignee option. Repeat as needed.")
     parser.add_argument("--label", action="append", default=[], help="Raw label option. Repeat as needed.")
@@ -161,6 +167,7 @@ def main() -> int:
             base_ref=args.base,
             head_ref=args.head,
             issue_hints=list(args.issue_hint or []),
+            test_commands=list(args.test_command or []),
             reviewers=list(args.reviewer or []),
             assignees=list(args.assignee or []),
             labels=list(args.label or []),

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/collect_pr_create_context.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/collect_pr_create_context.py
@@ -119,6 +119,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repo", default=None, help="Optional GitHub repo slug such as owner/name.")
     parser.add_argument("--base", default=None, help="Optional explicit base branch.")
     parser.add_argument("--head", default=None, help="Optional explicit head branch.")
+    parser.add_argument(
+        "--issue-hint",
+        action="append",
+        default=[],
+        help="Trusted explicit issue hint such as `15` or `#15`. Repeat as needed.",
+    )
     parser.add_argument("--reviewer", action="append", default=[], help="Raw reviewer option. Repeat as needed.")
     parser.add_argument("--assignee", action="append", default=[], help="Raw assignee option. Repeat as needed.")
     parser.add_argument("--label", action="append", default=[], help="Raw label option. Repeat as needed.")
@@ -148,18 +154,22 @@ def main() -> int:
     repo_root = Path(args.repo_root).resolve()
     profile_path = resolve_profile_path(args.profile, repo_root)
     repo_profile = load_repo_profile(profile_path)
-    context = build_context(
-        repo_root=repo_root,
-        repo_slug=args.repo,
-        base_ref=args.base,
-        head_ref=args.head,
-        reviewers=list(args.reviewer or []),
-        assignees=list(args.assignee or []),
-        labels=list(args.label or []),
-        milestone=args.milestone,
-        draft=args.draft,
-        no_maintainer_edit=args.no_maintainer_edit,
-    )
+    try:
+        context = build_context(
+            repo_root=repo_root,
+            repo_slug=args.repo,
+            base_ref=args.base,
+            head_ref=args.head,
+            issue_hints=list(args.issue_hint or []),
+            reviewers=list(args.reviewer or []),
+            assignees=list(args.assignee or []),
+            labels=list(args.label or []),
+            milestone=args.milestone,
+            draft=args.draft,
+            no_maintainer_edit=args.no_maintainer_edit,
+        )
+    except ValueError as exc:
+        raise SystemExit(f"[ERROR] {exc}") from exc
     context["repo_profile_name"] = repo_profile.get("name")
     context["repo_profile_path"] = profile_path.as_posix()
     context["repo_profile_summary"] = repo_profile.get("summary")

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/collect_pr_create_context.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/collect_pr_create_context.py
@@ -129,7 +129,10 @@ def parse_args() -> argparse.Namespace:
         "--test-command",
         action="append",
         default=[],
-        help="Trusted exact test command to allow in positive Testing claims. Repeat as needed.",
+        help=(
+            "Trusted exact test command to allow in positive Testing claims. "
+            "Must be a single-line command without backticks. Repeat as needed."
+        ),
     )
     parser.add_argument("--reviewer", action="append", default=[], help="Raw reviewer option. Repeat as needed.")
     parser.add_argument("--assignee", action="append", default=[], help="Raw assignee option. Repeat as needed.")

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/lint_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/lint_pr_create.py
@@ -9,7 +9,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from pr_create_tools import PR_TITLE_RE
+from pr_create_tools import PR_TITLE_RE, canonical_issue_number
 
 
 PLACEHOLDER_PATTERNS = [
@@ -130,7 +130,7 @@ def parse_diff_totals(diff_stat: str | None) -> dict[str, int]:
 def referenced_issue_numbers(text: str) -> list[str]:
     seen: list[str] = []
     for match in ISSUE_REF_PATTERN.finditer(text):
-        number = match.group("number")
+        number = canonical_issue_number(match.group("number"))
         if number not in seen:
             seen.append(number)
     return seen
@@ -335,7 +335,11 @@ def collect_candidate_findings(context: dict[str, Any], title: str, body: str) -
     bodies = section_bodies(body)
     asserted_body = asserted_claim_text(body)
     asserted_bodies = section_bodies(asserted_body)
-    issue_hints = set(str(item) for item in context.get("issue_reference_hints", {}).get("numbers", []))
+    issue_hints = {
+        canonical_issue_number(str(item))
+        for item in context.get("issue_reference_hints", {}).get("numbers", [])
+        if str(item).strip()
+    }
     runtime_count = int(((context.get("changed_file_groups") or {}).get("runtime") or {}).get("count", 0))
     testing_signals = context.get("testing_signal_candidates") or {}
     allowed_commands = set(str(item).strip() for item in testing_signals.get("exact_commands", []) if str(item).strip())
@@ -370,7 +374,10 @@ def collect_candidate_findings(context: dict[str, Any], title: str, body: str) -
             )
 
     all_refs = set(referenced_issue_numbers(asserted_body))
-    closing_refs = {match.group("number") for match in CLOSING_REF_PATTERN.finditer(asserted_body)}
+    closing_refs = {
+        canonical_issue_number(match.group("number"))
+        for match in CLOSING_REF_PATTERN.finditer(asserted_body)
+    }
     if all_refs and not all_refs.issubset(issue_hints):
         unsupported_claims.append(
             "Issue references are present without matching issue hints from the process packet."

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/lint_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/lint_pr_create.py
@@ -335,11 +335,15 @@ def collect_candidate_findings(context: dict[str, Any], title: str, body: str) -
     bodies = section_bodies(body)
     asserted_body = asserted_claim_text(body)
     asserted_bodies = section_bodies(asserted_body)
-    issue_hints = {
-        canonical_issue_number(str(item))
-        for item in context.get("issue_reference_hints", {}).get("numbers", [])
-        if str(item).strip()
-    }
+    issue_hints: set[str] = set()
+    for item in context.get("issue_reference_hints", {}).get("numbers", []):
+        normalized_item = str(item).strip()
+        if not normalized_item:
+            continue
+        try:
+            issue_hints.add(canonical_issue_number(normalized_item))
+        except (TypeError, ValueError):
+            continue
     runtime_count = int(((context.get("changed_file_groups") or {}).get("runtime") or {}).get("count", 0))
     testing_signals = context.get("testing_signal_candidates") or {}
     allowed_commands = set(str(item).strip() for item in testing_signals.get("exact_commands", []) if str(item).strip())

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/pr_create_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/pr_create_tools.py
@@ -152,6 +152,10 @@ def normalize_path(path: str) -> str:
     return path.replace("\\", "/")
 
 
+def canonical_issue_number(number: str) -> str:
+    return str(int(number))
+
+
 def infer_repo_slug(repo_root: Path) -> str | None:
     try:
         remote = run_git(["config", "--get", "remote.origin.url"], cwd=repo_root).strip()
@@ -405,7 +409,7 @@ def extract_issue_numbers(text: str | None) -> list[str]:
         return []
     seen: list[str] = []
     for match in ISSUE_REF_PATTERN.finditer(text):
-        number = match.group("number")
+        number = canonical_issue_number(match.group("number"))
         if number not in seen:
             seen.append(number)
     return seen
@@ -422,7 +426,7 @@ def normalize_explicit_issue_hints(values: Iterable[Any] | None) -> list[str]:
         if not match:
             invalid.append(text)
             continue
-        number = match.group("number")
+        number = canonical_issue_number(match.group("number"))
         if number not in normalized:
             normalized.append(number)
     if invalid:

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/pr_create_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/pr_create_tools.py
@@ -27,6 +27,7 @@ NAMED_TEMPLATE_GLOBS = [
     "docs/PULL_REQUEST_TEMPLATE/*.md",
 ]
 ISSUE_REF_PATTERN = re.compile(r"#(?P<number>\d+)")
+EXPLICIT_ISSUE_HINT_PATTERN = re.compile(r"^#?(?P<number>[1-9]\d*)$")
 
 
 def read_utf8_text(path: Path) -> str:
@@ -410,6 +411,29 @@ def extract_issue_numbers(text: str | None) -> list[str]:
     return seen
 
 
+def normalize_explicit_issue_hints(values: Iterable[Any] | None) -> list[str]:
+    normalized: list[str] = []
+    invalid: list[str] = []
+    for value in values or []:
+        text = str(value).strip()
+        if not text:
+            continue
+        match = EXPLICIT_ISSUE_HINT_PATTERN.fullmatch(text)
+        if not match:
+            invalid.append(text)
+            continue
+        number = match.group("number")
+        if number not in normalized:
+            normalized.append(number)
+    if invalid:
+        invalid_values = ", ".join(repr(item) for item in invalid)
+        raise ValueError(
+            "Explicit issue hints must be exact issue numbers like `15` or `#15`; "
+            f"got {invalid_values}."
+        )
+    return normalized
+
+
 def select_pr_template(repo_root: Path) -> dict[str, Any]:
     default_candidates = [normalize_path(str(repo_root / path)) for path in DEFAULT_TEMPLATE_PATHS if (repo_root / path).is_file()]
     named_candidates: list[str] = []
@@ -527,6 +551,7 @@ def build_context(
     repo_slug: str | None = None,
     base_ref: str | None = None,
     head_ref: str | None = None,
+    issue_hints: list[str] | None = None,
     reviewers: list[str] | None = None,
     assignees: list[str] | None = None,
     labels: list[str] | None = None,
@@ -546,15 +571,20 @@ def build_context(
     commit_subjects = load_commit_subjects(repo_root, resolved_base, resolved_head)
     template_selection = select_pr_template(repo_root)
     rule_paths = template_file_paths(repo_root, template_selection)
+    explicit_issue_hints = normalize_explicit_issue_hints(issue_hints)
+    branch_issue_hints = extract_issue_numbers(resolved_head)
+    commit_issue_hints = extract_issue_numbers(" ".join(commit_subjects))
 
     template_text = read_text_if_exists(Path(template_selection["selected_path"])) if template_selection.get("selected_path") else None
     instructions_text = read_text_if_exists(repo_root / ".github/instructions/pull-request.instructions.md")
     commit_instructions_text = read_text_if_exists(repo_root / ".github/instructions/commit-message.instructions.md")
     issue_hints = sorted(
         {
-            *extract_issue_numbers(resolved_head),
-            *extract_issue_numbers(" ".join(commit_subjects)),
-        }
+            *branch_issue_hints,
+            *commit_issue_hints,
+            *explicit_issue_hints,
+        },
+        key=int,
     )
 
     try:
@@ -599,7 +629,10 @@ def build_context(
         "issue_reference_hints": {
             "numbers": issue_hints,
             "branch": resolved_head,
+            "branch_numbers": branch_issue_hints,
             "commit_subjects": commit_subjects,
+            "commit_numbers": commit_issue_hints,
+            "operator_supplied": explicit_issue_hints,
         },
         "testing_signal_candidates": {
             "exact_commands": [],

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/pr_create_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/pr_create_tools.py
@@ -434,6 +434,27 @@ def normalize_explicit_issue_hints(values: Iterable[Any] | None) -> list[str]:
     return normalized
 
 
+def normalize_exact_test_commands(values: Iterable[Any] | None) -> list[str]:
+    normalized: list[str] = []
+    invalid: list[str] = []
+    for value in values or []:
+        text = str(value).strip()
+        if not text:
+            continue
+        if any(token in text for token in ("\r", "\n", "`")):
+            invalid.append(text)
+            continue
+        if text not in normalized:
+            normalized.append(text)
+    if invalid:
+        invalid_values = ", ".join(repr(item) for item in invalid)
+        raise ValueError(
+            "Explicit test commands must be single-line exact commands without backticks; "
+            f"got {invalid_values}."
+        )
+    return normalized
+
+
 def select_pr_template(repo_root: Path) -> dict[str, Any]:
     default_candidates = [normalize_path(str(repo_root / path)) for path in DEFAULT_TEMPLATE_PATHS if (repo_root / path).is_file()]
     named_candidates: list[str] = []
@@ -552,6 +573,7 @@ def build_context(
     base_ref: str | None = None,
     head_ref: str | None = None,
     issue_hints: list[str] | None = None,
+    test_commands: list[str] | None = None,
     reviewers: list[str] | None = None,
     assignees: list[str] | None = None,
     labels: list[str] | None = None,
@@ -572,6 +594,7 @@ def build_context(
     template_selection = select_pr_template(repo_root)
     rule_paths = template_file_paths(repo_root, template_selection)
     explicit_issue_hints = normalize_explicit_issue_hints(issue_hints)
+    explicit_test_commands = normalize_exact_test_commands(test_commands)
     branch_issue_hints = extract_issue_numbers(resolved_head)
     commit_issue_hints = extract_issue_numbers(" ".join(commit_subjects))
 
@@ -635,8 +658,9 @@ def build_context(
             "operator_supplied": explicit_issue_hints,
         },
         "testing_signal_candidates": {
-            "exact_commands": [],
-            "supports_positive_testing_claims": False,
+            "exact_commands": explicit_test_commands,
+            "operator_supplied": explicit_test_commands,
+            "supports_positive_testing_claims": bool(explicit_test_commands),
             "test_files_changed": int((summarize_groups(groups).get("tests") or {}).get("count", 0)) > 0,
         },
         "duplicate_check_hint": duplicate_hint,

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/smoke_gh_create_pr.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/smoke_gh_create_pr.py
@@ -183,7 +183,7 @@ def init_repo(repo_root: Path, origin_root: Path) -> None:
     write_text(repo_root / "src" / "creator.py", "VALUE = 2\n")
     write_text(repo_root / "tests" / "test_creator.py", "def test_smoke_fixture():\n    assert True\n")
     run_git(repo_root, ["add", "."])
-    run_git(repo_root, ["commit", "-m", "feat(pr-create): add guarded creator #42"])
+    run_git(repo_root, ["commit", "-m", "feat(pr-create): add guarded creator"])
     run_git(repo_root, ["push", "-u", "origin", "feature/pr-create-guard"])
 
 
@@ -235,6 +235,8 @@ def main() -> int:
                 str(repo_root),
                 "--repo",
                 "owner/repo",
+                "--issue-hint",
+                "42",
                 "--draft",
                 "--reviewer",
                 "alice",

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_build_pr_create_packets.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_build_pr_create_packets.py
@@ -20,11 +20,11 @@ def collected_context() -> dict:
         "resolved_base": "main",
         "local_head_oid": "abc123",
         "remote_head_oid": "abc123",
-        "changed_files": ["src/creator.py", "tests/test_creator.py"],
+        "changed_files": ["src/creator.py", "README.md", "tests/test_creator.py"],
         "changed_file_groups": {
             "runtime": {"count": 1, "sample_files": ["src/creator.py"]},
             "automation": {"count": 0, "sample_files": []},
-            "docs": {"count": 0, "sample_files": []},
+            "docs": {"count": 1, "sample_files": ["README.md"]},
             "tests": {"count": 1, "sample_files": ["tests/test_creator.py"]},
             "config": {"count": 0, "sample_files": []},
             "other": {"count": 0, "sample_files": []},
@@ -36,10 +36,17 @@ def collected_context() -> dict:
         },
         "expected_template_sections": list(REPO_TEMPLATE_SECTIONS),
         "duplicate_check_hint": {"status": "clear", "matched_repo_slug": "owner/repo", "matched_head": "feature/pr-create"},
-        "issue_reference_hints": {"numbers": ["42"], "branch": "feature/pr-create", "commit_subjects": []},
+        "issue_reference_hints": {
+            "numbers": ["42"],
+            "branch": "feature/pr-create",
+            "branch_numbers": ["42"],
+            "commit_subjects": [],
+            "commit_numbers": [],
+            "operator_supplied": ["42"],
+        },
         "testing_signal_candidates": {"exact_commands": [], "supports_positive_testing_claims": False, "test_files_changed": True},
         "create_options": {"reviewers": [], "assignees": [], "labels": [], "milestone": None, "draft": False, "no_maintainer_edit": False},
-        "diff_stat": " 2 files changed, 4 insertions(+), 1 deletion(-)",
+        "diff_stat": " 3 files changed, 5 insertions(+), 1 deletion(-)",
         "repo_profile_name": "default",
         "repo_profile_path": "profiles/default/profile.json",
         "repo_profile_summary": "Default profile",
@@ -89,6 +96,8 @@ class BuildPrCreatePacketsTests(unittest.TestCase):
         self.assertNotIn("recommended_workers", packets["orchestrator.json"])
         self.assertNotIn("optional_workers", packets["orchestrator.json"])
         self.assertNotIn("review_overrides", packets["global_packet.json"])
+        self.assertEqual(packets["process_packet.json"]["issue_reference_hints"]["operator_supplied"], ["42"])
+        self.assertEqual(packets["synthesis_packet.json"]["issue_reference_hints"]["numbers"], ["42"])
         self.assertIn(
             "restart/reload, rollout, and consumer migration/compatibility claims are blocked by default",
             packets["rules_packet.json"]["strict_claim_gates"],
@@ -97,7 +106,7 @@ class BuildPrCreatePacketsTests(unittest.TestCase):
             "unchecked template checklist items are not treated as asserted claims until checked or rewritten as prose",
             packets["rules_packet.json"]["strict_claim_gates"],
         )
-        self.assertEqual(build_result["review_mode_baseline"], "local-only")
+        self.assertEqual(build_result["review_mode_baseline"], "targeted-delegation")
         self.assertIn("recommended_workers", build_result)
         self.assertIn("optional_workers", build_result)
         self.assertEqual(build_result["delegation_non_use_cases"], builder.contract.DELEGATION_NON_USE_CASES)

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_build_pr_create_packets.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_build_pr_create_packets.py
@@ -44,7 +44,12 @@ def collected_context() -> dict:
             "commit_numbers": [],
             "operator_supplied": ["42"],
         },
-        "testing_signal_candidates": {"exact_commands": [], "supports_positive_testing_claims": False, "test_files_changed": True},
+        "testing_signal_candidates": {
+            "exact_commands": ["python -m unittest"],
+            "operator_supplied": ["python -m unittest"],
+            "supports_positive_testing_claims": True,
+            "test_files_changed": True,
+        },
         "create_options": {"reviewers": [], "assignees": [], "labels": [], "milestone": None, "draft": False, "no_maintainer_edit": False},
         "diff_stat": " 3 files changed, 5 insertions(+), 1 deletion(-)",
         "repo_profile_name": "default",
@@ -71,7 +76,7 @@ def lint_report() -> dict:
             "required_sections_status": {"required": list(REPO_TEMPLATE_SECTIONS)},
             "supported_claims": [{"cluster": "runtime", "basis": "runtime files changed", "evidence_anchor": "src/creator.py"}],
             "issue_reference_hints": {"numbers": ["42"]},
-            "testing_evidence_status": {"exact_commands": []},
+            "testing_evidence_status": {"exact_commands": ["python -m unittest"]},
             "coverage_gaps": [],
             "focused_packet_hint": "runtime_packet.json",
         },
@@ -98,6 +103,7 @@ class BuildPrCreatePacketsTests(unittest.TestCase):
         self.assertNotIn("review_overrides", packets["global_packet.json"])
         self.assertEqual(packets["process_packet.json"]["issue_reference_hints"]["operator_supplied"], ["42"])
         self.assertEqual(packets["synthesis_packet.json"]["issue_reference_hints"]["numbers"], ["42"])
+        self.assertEqual(packets["testing_packet.json"]["testing_signal_candidates"]["operator_supplied"], ["python -m unittest"])
         self.assertIn(
             "restart/reload, rollout, and consumer migration/compatibility claims are blocked by default",
             packets["rules_packet.json"]["strict_claim_gates"],

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_collect_pr_create_context.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_collect_pr_create_context.py
@@ -102,6 +102,7 @@ class CollectPrCreateContextTests(unittest.TestCase):
                 "    return {\n"
                 "        \"builder_compatibility\": {\"status\": \"current\"},\n"
                 "        \"captured_issue_hints\": kwargs.get(\"issue_hints\"),\n"
+                "        \"captured_test_commands\": kwargs.get(\"test_commands\"),\n"
                 "    }\n",
             )
             write_text(
@@ -152,6 +153,10 @@ class CollectPrCreateContextTests(unittest.TestCase):
                     "#15",
                     "--issue-hint",
                     "27",
+                    "--test-command",
+                    "python -m unittest",
+                    "--test-command",
+                    "python smoke.py",
                     "--output",
                     str(output_path),
                 ]
@@ -168,6 +173,7 @@ class CollectPrCreateContextTests(unittest.TestCase):
             payload = json.loads(output_path.read_text(encoding="utf-8"))
             self.assertEqual(exit_code, 0)
             self.assertEqual(payload["captured_issue_hints"], ["#15", "27"])
+            self.assertEqual(payload["captured_test_commands"], ["python -m unittest", "python smoke.py"])
 
 
 if __name__ == "__main__":

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_collect_pr_create_context.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_collect_pr_create_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 import tempfile
 import unittest
@@ -74,6 +75,99 @@ class CollectPrCreateContextTests(unittest.TestCase):
                 sys.modules.pop(module_name, None)
 
         self.assertEqual(module.BUILDER_SCRIPTS_DIR, builder_scripts_dir.resolve())
+
+    def test_main_passes_explicit_issue_hints_to_build_context(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = Path(tmp_dir)
+            override_scripts_dir = repo_root / ".agents" / "skills" / "gh-create-pr" / "scripts"
+            builder_scripts_dir = (
+                repo_root
+                / ".codex"
+                / "vendor"
+                / "packetflow_foundry"
+                / "builders"
+                / "packet-workflow"
+                / "retained-skills"
+                / "scripts"
+            )
+            skill_root = override_scripts_dir.parent
+
+            write_text(
+                override_scripts_dir / "collect_pr_create_context.py",
+                (SCRIPT_DIR / "collect_pr_create_context.py").read_text(encoding="utf-8"),
+            )
+            write_text(
+                override_scripts_dir / "pr_create_tools.py",
+                "def build_context(**kwargs):\n"
+                "    return {\n"
+                "        \"builder_compatibility\": {\"status\": \"current\"},\n"
+                "        \"captured_issue_hints\": kwargs.get(\"issue_hints\"),\n"
+                "    }\n",
+            )
+            write_text(
+                skill_root / "profiles" / "default" / "profile.json",
+                "{\n"
+                "  \"name\": \"default\",\n"
+                "  \"summary\": \"Default profile\"\n"
+                "}\n",
+            )
+            write_text(
+                builder_scripts_dir / "packet_workflow_versioning.py",
+                "def classify_builder_compatibility(**_kwargs):\n"
+                "    return {\"status\": \"current\"}\n\n"
+                "def extract_profile_versioning(_value):\n"
+                "    return None\n\n"
+                "def extract_skill_builder_versioning(_value):\n"
+                "    return None\n\n"
+                "def format_runtime_warning(_value):\n"
+                "    return \"warning\"\n\n"
+                "def load_builder_versioning():\n"
+                "    return {\"builder_family\": \"packet-workflow\", \"builder_semver\": \"1.0.0\"}\n\n"
+                "def load_json_document(_path):\n"
+                "    return {}\n",
+            )
+
+            module_name = "temp_collect_pr_create_context_issue_hints"
+            original_sys_path = list(sys.path)
+            original_argv = list(sys.argv)
+            original_pr_create_tools = sys.modules.pop("pr_create_tools", None)
+            original_versioning = sys.modules.pop("packet_workflow_versioning", None)
+            try:
+                sys.path.insert(0, str(override_scripts_dir))
+                spec = importlib.util.spec_from_file_location(
+                    module_name,
+                    override_scripts_dir / "collect_pr_create_context.py",
+                )
+                self.assertIsNotNone(spec)
+                self.assertIsNotNone(spec.loader)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+
+                output_path = repo_root / "context.json"
+                sys.argv = [
+                    "collect_pr_create_context.py",
+                    "--repo-root",
+                    str(repo_root),
+                    "--issue-hint",
+                    "#15",
+                    "--issue-hint",
+                    "27",
+                    "--output",
+                    str(output_path),
+                ]
+                exit_code = module.main()
+            finally:
+                sys.path[:] = original_sys_path
+                sys.argv[:] = original_argv
+                if original_pr_create_tools is not None:
+                    sys.modules["pr_create_tools"] = original_pr_create_tools
+                if original_versioning is not None:
+                    sys.modules["packet_workflow_versioning"] = original_versioning
+                sys.modules.pop(module_name, None)
+
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(payload["captured_issue_hints"], ["#15", "27"])
 
 
 if __name__ == "__main__":

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_collect_pr_create_context.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_collect_pr_create_context.py
@@ -166,8 +166,12 @@ class CollectPrCreateContextTests(unittest.TestCase):
                 sys.argv[:] = original_argv
                 if original_pr_create_tools is not None:
                     sys.modules["pr_create_tools"] = original_pr_create_tools
+                else:
+                    sys.modules.pop("pr_create_tools", None)
                 if original_versioning is not None:
                     sys.modules["packet_workflow_versioning"] = original_versioning
+                else:
+                    sys.modules.pop("packet_workflow_versioning", None)
                 sys.modules.pop(module_name, None)
 
             payload = json.loads(output_path.read_text(encoding="utf-8"))

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_lint_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_lint_pr_create.py
@@ -151,6 +151,7 @@ def collected_context() -> dict:
         },
         "testing_signal_candidates": {
             "exact_commands": [],
+            "operator_supplied": [],
             "supports_positive_testing_claims": False,
             "test_files_changed": True,
         },
@@ -266,6 +267,34 @@ class LintPrCreateTests(unittest.TestCase):
                     "  - Revert the docs text.",
                 ],
                 classification="- [x] Docs",
+            ),
+        )
+
+        self.assertEqual(findings["detected"]["unsupported_claims"], [])
+
+    def test_candidate_findings_allow_positive_testing_claim_with_trusted_command(self) -> None:
+        context = collected_context()
+        context["testing_signal_candidates"]["exact_commands"] = ["python -m pytest"]
+        context["testing_signal_candidates"]["operator_supplied"] = ["python -m pytest"]
+        context["testing_signal_candidates"]["supports_positive_testing_claims"] = True
+
+        findings = lint.collect_candidate_findings(
+            context,
+            "feat(pr-create): create guarded PRs",
+            "\n".join(
+                [
+                    "## Why",
+                    "Open a guarded PR.",
+                    "## What changed",
+                    "- Added validator/apply gates.",
+                    "## How",
+                    "- Keep create fail-closed.",
+                    "## Risk / Rollback",
+                    "- Re-run validation.",
+                    "## Testing",
+                    "- Ran `python -m pytest`.",
+                    "Refs: #42",
+                ]
             ),
         )
 

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_lint_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_lint_pr_create.py
@@ -325,6 +325,28 @@ class LintPrCreateTests(unittest.TestCase):
             findings["detected"]["unsupported_claims"],
         )
 
+    def test_candidate_findings_allow_canonicalized_issue_refs(self) -> None:
+        context = collected_context()
+        context["issue_reference_hints"]["numbers"] = ["1"]
+
+        findings = lint.collect_candidate_findings(
+            context,
+            "feat(pr-create): create guarded PRs",
+            candidate_body(
+                what_changed="- Added validator/apply gates.",
+                why=["- Open a guarded PR.", "- Refs: #01", "- Fixes: #01"],
+                how="- Keep create fail-closed.",
+                risk=[
+                    "- Risk areas:",
+                    "  - Validation could drift.",
+                    "- Rollback / mitigation:",
+                    "  - Re-run validation.",
+                ],
+            ),
+        )
+
+        self.assertEqual(findings["detected"]["unsupported_claims"], [])
+
     def test_candidate_findings_allow_internal_migration_batch_wording(self) -> None:
         findings = lint.collect_candidate_findings(
             collected_context(),

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_lint_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_lint_pr_create.py
@@ -347,6 +347,31 @@ class LintPrCreateTests(unittest.TestCase):
 
         self.assertEqual(findings["detected"]["unsupported_claims"], [])
 
+    def test_candidate_findings_ignore_invalid_issue_hint_context_values(self) -> None:
+        context = collected_context()
+        context["issue_reference_hints"]["numbers"] = ["bogus"]
+
+        findings = lint.collect_candidate_findings(
+            context,
+            "feat(pr-create): create guarded PRs",
+            candidate_body(
+                what_changed="- Added validator/apply gates.",
+                why=["- Open a guarded PR.", "- Refs: #1"],
+                how="- Keep create fail-closed.",
+                risk=[
+                    "- Risk areas:",
+                    "  - Validation could drift.",
+                    "- Rollback / mitigation:",
+                    "  - Re-run validation.",
+                ],
+            ),
+        )
+
+        self.assertIn(
+            "Issue references are present without matching issue hints from the process packet.",
+            findings["detected"]["unsupported_claims"],
+        )
+
     def test_candidate_findings_allow_internal_migration_batch_wording(self) -> None:
         findings = lint.collect_candidate_findings(
             collected_context(),

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_pr_create_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_pr_create_tools.py
@@ -170,6 +170,30 @@ class PrCreateToolsTests(unittest.TestCase):
             self.assertEqual(context["issue_reference_hints"]["commit_numbers"], [])
             self.assertEqual(context["issue_reference_hints"]["operator_supplied"], ["15"])
 
+    def test_build_context_accepts_explicit_test_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo_root = root / "repo"
+            origin_root = root / "origin.git"
+            repo_root.mkdir()
+            init_repo(repo_root, origin_root)
+
+            context = tools.build_context(
+                repo_root=repo_root,
+                repo_slug="owner/repo",
+                test_commands=["python -m unittest", "python -m unittest", "python smoke.py"],
+            )
+
+            self.assertEqual(
+                context["testing_signal_candidates"]["exact_commands"],
+                ["python -m unittest", "python smoke.py"],
+            )
+            self.assertEqual(
+                context["testing_signal_candidates"]["operator_supplied"],
+                ["python -m unittest", "python smoke.py"],
+            )
+            self.assertTrue(context["testing_signal_candidates"]["supports_positive_testing_claims"])
+
     def test_build_context_rejects_free_form_explicit_issue_hints(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -183,6 +207,28 @@ class PrCreateToolsTests(unittest.TestCase):
                     repo_root=repo_root,
                     repo_slug="owner/repo",
                     issue_hints=["Refs: #42"],
+                )
+
+    def test_build_context_rejects_multiline_or_backticked_test_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo_root = root / "repo"
+            origin_root = root / "origin.git"
+            repo_root.mkdir()
+            init_repo(repo_root, origin_root)
+
+            with self.assertRaisesRegex(ValueError, "Explicit test commands must be single-line exact commands"):
+                tools.build_context(
+                    repo_root=repo_root,
+                    repo_slug="owner/repo",
+                    test_commands=["python -m unittest\npython smoke.py"],
+                )
+
+            with self.assertRaisesRegex(ValueError, "Explicit test commands must be single-line exact commands"):
+                tools.build_context(
+                    repo_root=repo_root,
+                    repo_slug="owner/repo",
+                    test_commands=["`python -m unittest`"],
                 )
 
     def test_select_pr_template_fails_closed_when_multiple_candidates_exist(self) -> None:

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_pr_create_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_pr_create_tools.py
@@ -141,6 +141,50 @@ class PrCreateToolsTests(unittest.TestCase):
             self.assertEqual(context["resolved_base"], "release")
             self.assertEqual(context["resolved_head"], "feature/pr-create")
 
+    def test_build_context_merges_explicit_issue_hints_when_branch_and_commits_have_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo_root = root / "repo"
+            origin_root = root / "origin.git"
+            repo_root.mkdir()
+            init_repo(repo_root, origin_root)
+
+            run_git(repo_root, ["checkout", "main"])
+            run_git(repo_root, ["checkout", "-b", "feature/pr-create-operator"])
+            run_git(repo_root, ["config", "branch.feature/pr-create-operator.gh-merge-base", "main"])
+            write_text(repo_root / "src" / "feature.py", "VALUE = 3\n")
+            run_git(repo_root, ["add", "."])
+            run_git(repo_root, ["commit", "-m", "feat(pr-create): add guarded creator"])
+            run_git(repo_root, ["push", "-u", "origin", "feature/pr-create-operator"])
+
+            context = tools.build_context(
+                repo_root=repo_root,
+                repo_slug="owner/repo",
+                base_ref="main",
+                head_ref="feature/pr-create-operator",
+                issue_hints=["#15", "15"],
+            )
+
+            self.assertEqual(context["issue_reference_hints"]["numbers"], ["15"])
+            self.assertEqual(context["issue_reference_hints"]["branch_numbers"], [])
+            self.assertEqual(context["issue_reference_hints"]["commit_numbers"], [])
+            self.assertEqual(context["issue_reference_hints"]["operator_supplied"], ["15"])
+
+    def test_build_context_rejects_free_form_explicit_issue_hints(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo_root = root / "repo"
+            origin_root = root / "origin.git"
+            repo_root.mkdir()
+            init_repo(repo_root, origin_root)
+
+            with self.assertRaisesRegex(ValueError, "Explicit issue hints must be exact issue numbers"):
+                tools.build_context(
+                    repo_root=repo_root,
+                    repo_slug="owner/repo",
+                    issue_hints=["Refs: #42"],
+                )
+
     def test_select_pr_template_fails_closed_when_multiple_candidates_exist(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_pr_create_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_pr_create_tools.py
@@ -170,6 +170,35 @@ class PrCreateToolsTests(unittest.TestCase):
             self.assertEqual(context["issue_reference_hints"]["commit_numbers"], [])
             self.assertEqual(context["issue_reference_hints"]["operator_supplied"], ["15"])
 
+    def test_build_context_canonicalizes_issue_hints_before_dedupe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo_root = root / "repo"
+            origin_root = root / "origin.git"
+            repo_root.mkdir()
+            init_repo(repo_root, origin_root)
+
+            run_git(repo_root, ["checkout", "main"])
+            run_git(repo_root, ["checkout", "-b", "feature/pr-create-leading-zero"])
+            run_git(repo_root, ["config", "branch.feature/pr-create-leading-zero.gh-merge-base", "main"])
+            write_text(repo_root / "src" / "feature.py", "VALUE = 3\n")
+            run_git(repo_root, ["add", "."])
+            run_git(repo_root, ["commit", "-m", "feat(pr-create): add guarded creator #01"])
+            run_git(repo_root, ["push", "-u", "origin", "feature/pr-create-leading-zero"])
+
+            context = tools.build_context(
+                repo_root=repo_root,
+                repo_slug="owner/repo",
+                base_ref="main",
+                head_ref="feature/pr-create-leading-zero",
+                issue_hints=["#1"],
+            )
+
+            self.assertEqual(context["issue_reference_hints"]["numbers"], ["1"])
+            self.assertEqual(context["issue_reference_hints"]["branch_numbers"], [])
+            self.assertEqual(context["issue_reference_hints"]["commit_numbers"], ["1"])
+            self.assertEqual(context["issue_reference_hints"]["operator_supplied"], ["1"])
+
     def test_build_context_accepts_explicit_test_commands(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_validate_pr_create.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/tests/test_validate_pr_create.py
@@ -135,7 +135,12 @@ def collected_context(repo_root: Path, *, repo_slug: str = "owner/repo") -> dict
         },
         "expected_template_sections": list(REPO_TEMPLATE_SECTIONS),
         "issue_reference_hints": {"numbers": ["42"], "branch": "feature/pr-create", "commit_subjects": []},
-        "testing_signal_candidates": {"exact_commands": [], "supports_positive_testing_claims": False, "test_files_changed": True},
+        "testing_signal_candidates": {
+            "exact_commands": [],
+            "operator_supplied": [],
+            "supports_positive_testing_claims": False,
+            "test_files_changed": True,
+        },
         "create_options": {
             "reviewers": ["Alice", "alice", "bob, alice"],
             "assignees": ["Carol", "carol"],
@@ -286,6 +291,38 @@ class ValidatePrCreateTests(unittest.TestCase):
 
         self.assertFalse(payload["valid"])
         self.assertIn("unsupported_claim", payload["stop_reasons"])
+
+    def test_validator_accepts_positive_testing_claim_with_trusted_command(self) -> None:
+        context = collected_context(Path.cwd())
+        context["testing_signal_candidates"]["exact_commands"] = ["python -m pytest"]
+        context["testing_signal_candidates"]["operator_supplied"] = ["python -m pytest"]
+        context["testing_signal_candidates"]["supports_positive_testing_claims"] = True
+        body = valid_body().replace("- Not run.", "- Ran `python -m pytest`.")
+        with (
+            mock.patch.object(validator.tools, "run_command", return_value="Logged in to github.com"),
+            mock.patch.object(validator.tools, "local_head_oid", return_value="abc123"),
+            mock.patch.object(validator.tools, "remote_head_oid", return_value="abc123"),
+            mock.patch.object(validator.tools, "load_changed_files_between", return_value=context["changed_files"]),
+            mock.patch.object(validator.tools, "select_pr_template", return_value=context["template_selection"]),
+            mock.patch.object(
+                validator.tools,
+                "duplicate_check_summary",
+                return_value={
+                    "status": "clear",
+                    "matched_repo_slug": "owner/repo",
+                    "matched_head": "feature/pr-create",
+                    "existing_pr_count": 0,
+                },
+            ),
+        ):
+            payload = validator.validate_pr_create(
+                context,
+                "feat(pr-create): create guarded PRs",
+                body,
+            )
+
+        self.assertTrue(payload["valid"])
+        self.assertTrue(payload["can_apply"])
 
     def test_validator_rejects_direct_consumer_migration_claim(self) -> None:
         self.assert_validator_rejects_consumer_claim("- Requires migration for consumers.")


### PR DESCRIPTION
## What changed
- Add trusted `--issue-hint` and `--test-command` collector inputs for retained `gh-create-pr`.
- Normalize explicit issue hints and exact test commands into the collected process/testing evidence.
- Keep the existing fail-closed validator gates while extending docs, packets, and regression coverage around the new trusted inputs.

## Why
- `gh-create-pr` should support issue references and positive testing claims when the supporting evidence comes from trusted operator context rather than branch metadata or ad hoc free-form text.
- Refs: #25

## How
- Accept only exact issue numbers and single-line exact test commands without backticks as trusted collector inputs.
- Extend the existing process/testing packet evidence model instead of weakening the strict issue-reference or testing-claim gates.

## Testing
- Validation / tests:
  - Ran `python -m pytest -s builders/packet-workflow/retained-skills/gh-create-pr/tests`
- Manual review:
  - Ran `python builders/packet-workflow/retained-skills/gh-create-pr/scripts/smoke_gh_create_pr.py`

## Compatibility / Adoption
- Consumer / vendor impact:
  - [x] None
- Details:
  - Consumers can optionally pass trusted `--issue-hint` and `--test-command` inputs; no required migration step changes.

## Risk / Rollback
- Risk areas:
  - Overly broad normalization would weaken the existing fail-closed issue and testing claim gates.
- Rollback / mitigation:
  - Revert the collector/context changes to remove the trusted input paths if validation behavior regresses.

## Reviewer Checklist
- [x] Linked issue, design note, or release item when applicable
- [x] Docs or templates updated if shared behavior changed
- [ ] Builder/tests updated with core contract/template/default changes
- [x] Consumer impact called out when applicable
- [x] Validation steps are specific enough to reproduce
- [x] Risk and rollback are concrete when behavior could regress

## PR Classification (optional)
- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] Docs
- [ ] Chore/Maintenance
- [ ] Build/CI
- [ ] Test

Justification:
Corrects retained `gh-create-pr` limitations so trusted operator context can authorize supported issue references and exact testing claims without loosening validator rules.
