### PR TITLE
fix(skills): harden Windows subprocess launches

### DIFF
--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/collect_release_copy_context.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/collect_release_copy_context.py
@@ -127,6 +127,7 @@ def run_command(args: list[str], cwd: Path, check: bool = True) -> str:
         args,
         cwd=str(cwd),
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         text=True,
         encoding="utf-8",
         check=False,

--- a/builders/packet-workflow/retained-skills/draft-release-copy/scripts/create_release_issue.py
+++ b/builders/packet-workflow/retained-skills/draft-release-copy/scripts/create_release_issue.py
@@ -19,6 +19,7 @@ def run_command(args: list[str], cwd: Path, check: bool = True) -> str:
             args,
             cwd=str(cwd),
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             encoding="utf-8",
             check=False,

--- a/builders/packet-workflow/retained-skills/gh-create-pr/scripts/smoke_gh_create_pr.py
+++ b/builders/packet-workflow/retained-skills/gh-create-pr/scripts/smoke_gh_create_pr.py
@@ -74,6 +74,7 @@ def run_python(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess
         text=True,
         encoding="utf-8",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:
@@ -89,6 +90,7 @@ def run_git(repo_root: Path, args: list[str]) -> None:
         text=True,
         encoding="utf-8",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:
@@ -108,6 +110,7 @@ def init_repo(repo_root: Path, origin_root: Path) -> None:
         text=True,
         encoding="utf-8",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/pr_writeup_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/pr_writeup_tools.py
@@ -54,6 +54,7 @@ def run_command(args: list[str], cwd: Path) -> str:
             cwd=str(cwd),
             check=True,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             encoding="utf-8",
         )

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/smoke_gh_fix_pr_writeup.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/scripts/smoke_gh_fix_pr_writeup.py
@@ -65,6 +65,7 @@ def run_python(args: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess
         text=True,
         encoding="utf-8",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:
@@ -80,6 +81,7 @@ def run_git(repo_root: Path, args: list[str]) -> None:
         text=True,
         encoding="utf-8",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_pr_writeup_tools.py
+++ b/builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_pr_writeup_tools.py
@@ -30,12 +30,13 @@ class PrWriteupToolsTests(unittest.TestCase):
     def test_load_local_diff_stat_uses_pr_scoped_merge_base(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
-            subprocess.run(["git", "init", "-b", "main"], cwd=str(repo_root), check=True, capture_output=True, text=True)
+            subprocess.run(["git", "init", "-b", "main"], cwd=str(repo_root), check=True, capture_output=True, stdin=subprocess.DEVNULL, text=True)
             subprocess.run(
                 ["git", "config", "user.name", "PacketFlow Tests"],
                 cwd=str(repo_root),
                 check=True,
                 capture_output=True,
+                stdin=subprocess.DEVNULL,
                 text=True,
             )
             subprocess.run(
@@ -43,16 +44,18 @@ class PrWriteupToolsTests(unittest.TestCase):
                 cwd=str(repo_root),
                 check=True,
                 capture_output=True,
+                stdin=subprocess.DEVNULL,
                 text=True,
             )
 
             (repo_root / "base.txt").write_text("base\n", encoding="utf-8")
-            subprocess.run(["git", "add", "base.txt"], cwd=str(repo_root), check=True, capture_output=True, text=True)
+            subprocess.run(["git", "add", "base.txt"], cwd=str(repo_root), check=True, capture_output=True, stdin=subprocess.DEVNULL, text=True)
             subprocess.run(
                 ["git", "commit", "-m", "base"],
                 cwd=str(repo_root),
                 check=True,
                 capture_output=True,
+                stdin=subprocess.DEVNULL,
                 text=True,
             )
 
@@ -61,26 +64,29 @@ class PrWriteupToolsTests(unittest.TestCase):
                 cwd=str(repo_root),
                 check=True,
                 capture_output=True,
+                stdin=subprocess.DEVNULL,
                 text=True,
             )
             (repo_root / "feature.txt").write_text("feature\n", encoding="utf-8")
-            subprocess.run(["git", "add", "feature.txt"], cwd=str(repo_root), check=True, capture_output=True, text=True)
+            subprocess.run(["git", "add", "feature.txt"], cwd=str(repo_root), check=True, capture_output=True, stdin=subprocess.DEVNULL, text=True)
             subprocess.run(
                 ["git", "commit", "-m", "feature"],
                 cwd=str(repo_root),
                 check=True,
                 capture_output=True,
+                stdin=subprocess.DEVNULL,
                 text=True,
             )
 
-            subprocess.run(["git", "checkout", "main"], cwd=str(repo_root), check=True, capture_output=True, text=True)
+            subprocess.run(["git", "checkout", "main"], cwd=str(repo_root), check=True, capture_output=True, stdin=subprocess.DEVNULL, text=True)
             (repo_root / "main-only.txt").write_text("main\n", encoding="utf-8")
-            subprocess.run(["git", "add", "main-only.txt"], cwd=str(repo_root), check=True, capture_output=True, text=True)
+            subprocess.run(["git", "add", "main-only.txt"], cwd=str(repo_root), check=True, capture_output=True, stdin=subprocess.DEVNULL, text=True)
             subprocess.run(
                 ["git", "commit", "-m", "main only"],
                 cwd=str(repo_root),
                 check=True,
                 capture_output=True,
+                stdin=subprocess.DEVNULL,
                 text=True,
             )
 
@@ -116,12 +122,13 @@ class PrWriteupToolsTests(unittest.TestCase):
     def test_infer_repo_slug_accepts_dotted_repo_names(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
-            subprocess.run(["git", "init", "-b", "main"], cwd=str(repo_root), check=True, capture_output=True, text=True)
+            subprocess.run(["git", "init", "-b", "main"], cwd=str(repo_root), check=True, capture_output=True, stdin=subprocess.DEVNULL, text=True)
             subprocess.run(
                 ["git", "remote", "add", "origin", "git@github.com:owner/my.repo.git"],
                 cwd=str(repo_root),
                 check=True,
                 capture_output=True,
+                stdin=subprocess.DEVNULL,
                 text=True,
             )
 

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/apply_commit_plan.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/apply_commit_plan.py
@@ -37,16 +37,18 @@ def run_git(
     check: bool = True,
     input_text: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=repo,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        input=input_text,
-        capture_output=True,
-        check=False,
-    )
+    run_kwargs: dict[str, Any] = {
+        "cwd": repo,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+        "input": input_text,
+        "capture_output": True,
+        "check": False,
+    }
+    if input_text is None:
+        run_kwargs["stdin"] = subprocess.DEVNULL
+    result = subprocess.run(["git", *args], **run_kwargs)
     if check and result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "git failed")
     return result

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/collect_commit_rules.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/collect_commit_rules.py
@@ -28,6 +28,7 @@ def run_git(repo: Path, args: list[str], check: bool = True) -> str:
         cwd=repo,
         text=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if check and result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/collect_worktree_context.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/collect_worktree_context.py
@@ -175,6 +175,7 @@ def run_git(repo: Path, args: list[str], check: bool = True) -> str:
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if check and result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/smoke_git_split_and_commit.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/scripts/smoke_git_split_and_commit.py
@@ -21,6 +21,7 @@ def run_python(args: list[str], *, cwd: Path | None = None) -> subprocess.Comple
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:
@@ -36,6 +37,7 @@ def run_git(repo_root: Path, args: list[str]) -> subprocess.CompletedProcess[str
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_git_split_and_commit_integration.py
+++ b/builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_git_split_and_commit_integration.py
@@ -23,6 +23,7 @@ def run_command(args: list[str], *, cwd: Path, check: bool = True) -> subprocess
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if check and result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/public-docs-sync/scripts/apply_public_docs_sync.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/scripts/apply_public_docs_sync.py
@@ -43,6 +43,7 @@ def run_git(repo_root: Path, args: list[str]) -> str:
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/public-docs-sync/scripts/collect_public_docs_sync_context.py
+++ b/builders/packet-workflow/retained-skills/public-docs-sync/scripts/collect_public_docs_sync_context.py
@@ -328,16 +328,18 @@ def run_command(
     check: bool = True,
     stdin_text: str | None = None,
 ) -> str:
-    result = subprocess.run(
-        args,
-        cwd=cwd,
-        input=stdin_text,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        capture_output=True,
-        check=False,
-    )
+    run_kwargs: dict[str, Any] = {
+        "cwd": cwd,
+        "input": stdin_text,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+        "capture_output": True,
+        "check": False,
+    }
+    if stdin_text is None:
+        run_kwargs["stdin"] = subprocess.DEVNULL
+    result = subprocess.run(args, **run_kwargs)
     if check and result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or f"{args[0]} failed"
         raise RuntimeError(detail)
@@ -649,6 +651,7 @@ def git_ref_exists(repo_root: Path, ref: str) -> bool:
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     return result.returncode == 0
@@ -669,6 +672,7 @@ def commit_exists(repo_root: Path, commit: str) -> bool:
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     return result.returncode == 0
@@ -682,6 +686,7 @@ def commit_is_ancestor(repo_root: Path, older: str, newer: str) -> bool:
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     return result.returncode == 0
@@ -917,6 +922,7 @@ def ensure_gh_auth(repo_root: Path) -> dict[str, Any]:
             encoding="utf-8",
             errors="replace",
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             check=False,
         )
     except FileNotFoundError:

--- a/builders/packet-workflow/retained-skills/reword-head-commit/scripts/reword_head_commit.py
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/scripts/reword_head_commit.py
@@ -279,6 +279,7 @@ def git_result(
         cwd=repo_root,
         text=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
         env=env,
     )

--- a/builders/packet-workflow/retained-skills/reword-head-commit/scripts/smoke_reword_head_commit.py
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/scripts/smoke_reword_head_commit.py
@@ -21,6 +21,7 @@ def run_git(repo: Path, *args: str, check: bool = True) -> str:
         cwd=repo,
         text=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if check and result.returncode != 0:
@@ -74,6 +75,7 @@ def main() -> int:
             [sys.executable, "-B", str(DRIVER_PATH), "--repo", str(repo), "--message-file", str(message_path), "--apply"],
             text=True,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             check=False,
         )
         if result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/reword-head-commit/tests/reword_head_commit_test_support.py
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/tests/reword_head_commit_test_support.py
@@ -42,6 +42,7 @@ def run_git(
         cwd=repo,
         text=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
         env=env,
     )

--- a/builders/packet-workflow/retained-skills/reword-head-commit/tests/test_reword_head_commit_smoke.py
+++ b/builders/packet-workflow/retained-skills/reword-head-commit/tests/test_reword_head_commit_smoke.py
@@ -14,6 +14,7 @@ class RewordHeadCommitSmokeTests(unittest.TestCase):
             [sys.executable, "-B", str(script_path)],
             text=True,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             check=False,
         )
 

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/apply_reword_plan.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/apply_reword_plan.py
@@ -45,6 +45,7 @@ def git_result(
         cwd=repo,
         text=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
         env=env,
     )

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/collect_commit_rules.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/collect_commit_rules.py
@@ -30,6 +30,7 @@ def run_git(repo: Path, args: list[str], check: bool = True) -> str:
         cwd=repo,
         text=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if check and result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/collect_recent_commits.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/collect_recent_commits.py
@@ -123,6 +123,7 @@ def run_git(repo: Path, args: list[str], check: bool = True) -> str:
         cwd=repo,
         text=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if check and result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_plan_contract.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_plan_contract.py
@@ -413,6 +413,7 @@ def run_git(repo: Path, args: list[str], *, check: bool = True) -> str:
         cwd=repo,
         text=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if check and result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_recent_commits.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_recent_commits.py
@@ -72,6 +72,7 @@ def run_python(
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode not in allowed:

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_runtime_paths.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/reword_runtime_paths.py
@@ -25,6 +25,7 @@ def run_git(repo: Path, args: list[str]) -> str:
         cwd=repo,
         text=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/smoke_reword_recent_commits.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/scripts/smoke_reword_recent_commits.py
@@ -25,6 +25,7 @@ def run_python(args: list[str], *, cwd: Path | None = None) -> subprocess.Comple
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:
@@ -40,6 +41,7 @@ def run_git(repo_root: Path, args: list[str]) -> subprocess.CompletedProcess[str
         encoding="utf-8",
         errors="replace",
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
     )
     if result.returncode != 0:

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/reword_test_support.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/reword_test_support.py
@@ -45,6 +45,7 @@ def run_git(
         cwd=repo,
         text=True,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         check=False,
         env=env,
     )

--- a/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_reword_workflow_smoke.py
+++ b/builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_reword_workflow_smoke.py
@@ -81,6 +81,7 @@ class RewordWorkflowSmokeTests(unittest.TestCase):
             [sys.executable, "-B", str(script_path)],
             text=True,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             check=False,
         )
 

--- a/builders/packet-workflow/retained-skills/weekly-update/scripts/weekly_update_lib.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/scripts/weekly_update_lib.py
@@ -327,6 +327,7 @@ def run_command(args: list[str], cwd: Path, *, check: bool = True) -> str:
             args,
             cwd=cwd,
             capture_output=True,
+            stdin=subprocess.DEVNULL,
             text=True,
             encoding="utf-8",
             errors="replace",

--- a/builders/packet-workflow/retained-skills/weekly-update/tests/test_weekly_update_analysis_ref.py
+++ b/builders/packet-workflow/retained-skills/weekly-update/tests/test_weekly_update_analysis_ref.py
@@ -26,6 +26,7 @@ def run_git(repo_root: Path, *args: str, env: dict[str, str] | None = None) -> s
         ["git", *args],
         cwd=repo_root,
         capture_output=True,
+        stdin=subprocess.DEVNULL,
         text=True,
         encoding="utf-8",
         errors="replace",


### PR DESCRIPTION
## What changed
- Defaulted retained-skill `subprocess.run(..., capture_output=True)`
  paths to `stdin=subprocess.DEVNULL` for Windows child-process safety.
- Kept wrappers that accept `input=` safe by adding `stdin` only when the
  child process does not consume explicit input text.
- Updated the affected smoke helpers and regression tests to exercise the
  Windows-safe launch path across retained-skill workflows.

## Why
- Fix the shared Windows handle-startup failures reported in the retained
  skill test matrix.
- Refs: #28

## How
- Patched the shared retained-skill `git`/`gh`/`python` subprocess
  wrappers first so downstream calls inherit the same safe stdin
  contract.
- Filled the remaining direct test and smoke helper launches where they
  bypassed those wrappers.
- Preserved existing `input=` behavior in the small set of wrappers that
  need to feed child-process stdin directly.

## Testing
- Validation / tests:
  - `python -m pytest builders/packet-workflow/retained-skills/reword-recent-commits/tests/test_reword_workflow_smoke.py -q`
  - `python -m pytest builders/packet-workflow/retained-skills/reword-head-commit/tests/test_reword_head_commit_smoke.py -q`
  - `python -m pytest builders/packet-workflow/retained-skills/gh-fix-pr-writeup/tests/test_pr_writeup_tools.py -q`
  - `python -m pytest builders/packet-workflow/retained-skills/git-split-and-commit/tests/test_git_split_and_commit_integration.py -q`
  - `python -m pytest builders/packet-workflow/retained-skills/weekly-update/tests/test_weekly_update_analysis_ref.py -q`
  - `python -m pytest builders/packet-workflow/retained-skills/gh-create-pr/tests/test_pr_create_tools.py -q`
- Manual review:
  - Reviewed the guarded commit and PR-create validation outputs after
    the Windows regression checks passed.

## Compatibility / Adoption
- Consumer / vendor impact:
  - [ ] None
  - [ ] Requires regenerating builder output
  - [ ] Requires updating project-local profiles or agents
  - [ ] Requires a migration note for vendored consumers
- Details:
  - This change updates retained-skill runtime and smoke/test helpers in
    the foundry checkout.

## Risk / Rollback
- Risk areas:
  - Subprocess wrappers that also support `input=` could regress if stdin
    handling changes are applied unconditionally.
- Rollback / mitigation:
  - Revert this commit to restore the previous subprocess behavior, then
    rerun the Windows retained-skill test matrix.

## Reviewer Checklist
- [x] Linked issue, design note, or release item when applicable
- [ ] Docs or templates updated if shared behavior changed
- [ ] Builder/tests updated with core contract/template/default changes
- [ ] Consumer impact called out when applicable
- [x] Validation steps are specific enough to reproduce
- [x] Risk and rollback are concrete when behavior could regress

## PR Classification (optional)
- [x] Bugfix

Justification:
- This corrects broken Windows subprocess startup behavior across
  multiple retained-skill workflows without changing the intended
  workflow semantics.
